### PR TITLE
docs: fix simple typo, specifiy -> specify

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pdftohtml -c -hidden -xml input.pdf output.xml
 ```
 
 The arguments *input.pdf* and *output.xml* are your input PDF file and the created XML file in pdf2xml format
-respectively. It is important that you specifiy the *-hidden* parameter when you're dealing with OCR-processed
+respectively. It is important that you specify the *-hidden* parameter when you're dealing with OCR-processed
 ("sandwich") PDFs. You can furthermore add the parameters *-f n* and *-l n* to set only a range of pages to be
 converted.
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `specify` rather than `specifiy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md